### PR TITLE
Review 3

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -15,6 +15,11 @@ Example
         // ...
     })
 
+    var sendBody = { m: 5678 }
+    khttp.post("http://example.com", sendBody, function(err, res, responseBody) {
+        // ...
+    })
+
 
 Api
 ---
@@ -48,6 +53,8 @@ k-http options (kinda like `request`):
   If the response is not valid json, returns the response string.
 - `auth` - object with fields `{ username: , password: }` used to build an
   "Authorization: Basic" header.  The fields `{ user: , pass: }` are also accepted.
+- `raw` - do not wait for and decode body, return immediately and let the caller
+  wait for `res.on('data')` events.
 
 http options used to construct a url from parts:
 - `protocol` - 'http:' or 'https:' (default 'http:')
@@ -67,6 +74,15 @@ khttp.request to make calls.
 
 The options are as in khttp.request.  Call-time options provided to
 `callre.request` override the default options.
+
+### khttp.call( method, urlOrOptions, [body,] callback(err, res, body) )
+
+Call `request` with the specified method.
+
+### khttp.get( urlOrOptions, [body,] callback(err, res, body) )
+
+The `call` method is also accessible as the conveinence methods `get`, `post`,
+`put`, `head`, `del`, and `patch`, which invoke `call` with the appropriate method.
 
 
 Related Work

--- a/Readme.md
+++ b/Readme.md
@@ -80,6 +80,7 @@ Related Work
 Chane Log
 ---------
 
+- 1.3.0 - fix options merging, add `get`/`put`/`post` etc aliases
 - 1.2.0 - harden socket timeout handling
 - 1.1.0 - `defaults()` function to return a pre-configured caller
 - 1.0.1 - speed access to res.body, readme edits

--- a/khttp.js
+++ b/khttp.js
@@ -151,7 +151,7 @@ module.exports = {
     request: krequest,
 
     defaults: function defaults(options) {
-        return {
+        var caller = {
             opts: mergeOptions({}, options),
             request: function(url, body, cb) {
                 var opts = {};
@@ -161,12 +161,37 @@ module.exports = {
                 return module.exports.request(opts, body, cb);
             },
             defaults: defaults,
-        }
+        };
+        return addAliases(caller);
     },
 
     // for testing
     allowDuplicateCallbacks: false,
 };
+addAliases(module.exports);
+
+// decorate the khttp caller with handy aliases
+function addAliases( caller ) {
+    caller.call = function call(method, url, body, cb) {
+        return caller.request(mergeOptions({method: method}, url), body, cb);
+    };
+    // make available the aliases `request` does, for familiarity
+    caller.get = function get(url, body, cb) { return caller.call('GET', url, body, cb) };
+    caller.head = function del(url, body, cb) { return caller.call('HEAD', url, body, cb) };
+    caller.post = function post(url, body, cb) { return caller.call('POST', url, body, cb) };
+    caller.put = function put(url, body, cb) { return caller.call('PUT', url, body, cb) };
+    caller.patch = function patch(url, body, cb) { return caller.call('PATCH', url, body, cb) };
+    caller.del = function del(url, body, cb) { return caller.call('DELETE', url, body, cb) };
+
+    return optimizeAccess(caller);
+}
+
+// optimize access to the object properties
+function optimizeAccess( object ) {
+    function F() {};
+    return F.prototype = object;
+    try { } finally { }
+}
 
 // decode json into object, or return the string if not valid json
 function try_json_decode( str ) {

--- a/khttp.js
+++ b/khttp.js
@@ -183,17 +183,18 @@ function try_json_encode( obj ) {
 // merge http request options, handling headers properly
 function mergeOptions( to, from ) {
     // special case convert url strings to url options
-    if (typeof from === 'string') {
-        to.url = from;
-        return;
-    }
+    if (typeof from === 'string') from = { url: from };
 
     // merge in new request options, but not any headers yet
     var existingHeaders = to.headers;
     for (var k in from) {
-        to[k] = from[k];
+        // the url is special, handle baseUrl-relative paths
+        if (k === 'url' && typeof from.url === 'string' && from.url[0] === '/' && to.url != null) {
+            to.url += from.url;
+        }
+        else to[k] = from[k];
     }
-    to.headers = existingHeaders;
+    if (existingHeaders != null) to.headers = existingHeaders;
 
     // then merge in headers from a valid headers object
     if (from.headers && typeof from.headers === 'object') {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "k-http",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "kinvey http",
   "main": "khttp.js",
   "engines": {

--- a/test-khttp.js
+++ b/test-khttp.js
@@ -443,6 +443,42 @@ describe ('khttp', function() {
         })
     })
 
+    describe ('shortcuts', function() {
+        it ('should make a get request', function(done) {
+            khttp.get("http://localhost:1337", "body", function(err, res, body) {
+                assert.ifError(err);
+                assert.equal(JSON.parse(body).method, 'GET');
+                done();
+            })
+        })
+
+        it ('should make a post request', function(done) {
+            khttp.post("http://localhost:1337", "body", function(err, res, body) {
+                assert.ifError(err);
+                assert.equal(JSON.parse(body).method, 'POST');
+                done();
+            })
+        })
+
+        it ('should make a del request', function(done) {
+            khttp.del("http://localhost:1337", "body", function(err, res, body) {
+                assert.ifError(err);
+                assert.equal(JSON.parse(body).method, 'DELETE');
+                done();
+            })
+        })
+
+        it ('defaults should have a get method', function(done) {
+            var defaults = khttp.defaults({ url: "http://localhost:1337" });
+            defaults.get("/path/to/resource", "body", function(err, res, body) {
+                assert.ifError(err);
+                assert.equal(JSON.parse(body).method, 'GET');
+                assert.equal(JSON.parse(body).url, '/path/to/resource');
+                done();
+            })
+        })
+    })
+
     describe ('performance', function() {
         it ('should use little cpu', function(done) {
             var caller = httpRequest;

--- a/test-khttp.js
+++ b/test-khttp.js
@@ -410,6 +410,13 @@ describe ('khttp', function() {
             })
         })
 
+        it ('should save options', function(done) {
+            var a = {a:1, b:2};
+            var b = khttp.defaults(a);
+            assert.deepEqual(b.opts, a);
+            done();
+        })
+
         it ('should pass headers to request', function(done) {
             var caller = khttp.defaults({ url: "http://localhost:1337" });
             caller.request({ json: true, headers: { 'x-tracer': uniq } }, function(err, res, body) {
@@ -444,7 +451,8 @@ describe ('khttp', function() {
             var cpu = process.cpuUsage();
             var t1 = Date.now();
             var uri = {
-                url: "https://google.com/login",        // 1.5k
+                url: "https://google.com/login",        // 1.5k, 30ms
+                url: "http://bing.com/",                // 256b, 21ms
             }
             for (var callCount=0; callCount<10; callCount++) {
                 caller(uri, callDone);
@@ -454,7 +462,8 @@ describe ('khttp', function() {
                 if (doneCount === callCount) {
                     var t2 = Date.now();
                     cpu = process.cpuUsage(cpu);
-                    console.log("%s: %d calls in %d ms, total cpu %d ms (%d bytes)", caller.name, callCount, t2-t1, cpu.user/1000 + cpu.system/1000, body.length);
+                    console.log("%s: %d https calls in %d ms, total cpu %d ms (%d bytes)",
+                        caller.name, callCount, t2-t1, cpu.user/1000 + cpu.system/1000, body.length);
                     // timed on a cpu with cpufreq/scaling_governor set to "performance":
                     // https small:    khttp: 20ms for 10, request: 32ms for 10 (1.5k)
                     done();

--- a/test-khttp.js
+++ b/test-khttp.js
@@ -388,6 +388,34 @@ describe ('khttp', function() {
         })
     })
 
+    describe ('options', function() {
+        it ('options.raw should not wait for body', function(done) {
+            var httpRequest = khttp.defaults({ raw: true }).request;
+            httpRequest(echoService, function(err, res) {
+                assert.ifError(err);
+                var chunks = [];
+                res.on('data', function(chunk) {
+                    chunks.push(chunk);
+                })
+                res.on('end', function() {
+                    assert(chunks.length > 0);
+                    done();
+                })
+            })
+        })
+
+        it ('options.raw should time out', function(done) {
+            var httpRequest = khttp.defaults({ raw: true }).request;
+            httpRequest({ url: echoService + '/slowcall', timeout: slowCallMs / 5 }, function(err, res, body) {
+                assert(!err);
+                res.on('error', function(err) {
+                    assert.equal(err.code, 'ESOCKETTIMEDOUT');
+                    done();
+                })
+            })
+        })
+    })
+
     describe ('defaults', function() {
         it ('should construct a caller', function(done) {
             var caller = khttp.defaults({ url: "http://example.com", headers: { uniq: uniq } });


### PR DESCRIPTION
changes between 1.2.0 and 1.3.0
- `khttp.call` function
- `raw` mode that does not wait for all the data
- `khttp.get`, `put`, `post` etc aliases
- `mergeOptions` fixes